### PR TITLE
fix less render

### DIFF
--- a/lib/compilers/less.js
+++ b/lib/compilers/less.js
@@ -16,7 +16,10 @@ module.exports = function (raw, compiler, filePath) {
     ? opts.paths.concat(paths)
     : paths
 
-  var res = less.renderSync(raw, opts)
+  var res;
+  less.render(raw, opts, function(e, result) {
+    res = result;
+  })
   // Less 2.0 returns an object instead rendered string
   if (typeof res === 'object') {
     res.imports.forEach(function (file) {

--- a/lib/compilers/options.js
+++ b/lib/compilers/options.js
@@ -29,6 +29,9 @@ module.exports = {
   coffee: {
     bare: true
   },
+  less: {
+    syncImport: true
+  },
   sass: {
     sourceComments: true
   }


### PR DESCRIPTION
你好，插件在编译vue组件里的less时报错，less并没有less.renderSync()方法。

但是我发现less.render在一般情况下都是同步的，虽然他的写法非常像异步。也就是说他实际上的执行顺序是这样：
``` javascript
less.render(raw, opts, function(e, result){
  console.log('1:  先执行callback');
})
console.log('2: 再执行下面的代码')
```

只有当less文件里使用了@import时，render方法才是异步的( https://github.com/less/less.js/issues/2546 )，所以我同时加了个默认配置syncImport: true。